### PR TITLE
Expose resetMaxErrors and setup

### DIFF
--- a/addon/services/honeybadger.js
+++ b/addon/services/honeybadger.js
@@ -89,14 +89,21 @@ export default Service.extend({
   },
 
   _getScript() {
+    let config = this._config();
+    let version = config.version || '2.2';
+
     return new Promise((resolve, reject) => {
       let script = document.createElement('script');
 
       script.type = 'text/javascript';
       script.async = true;
-      script.src = '//js.honeybadger.io/v2.2/honeybadger.min.js';
+      script.src = `//js.honeybadger.io/v${version}/honeybadger.min.js`;
       script.onload = resolve;
       script.onerror = reject;
+
+      if (config.environment === 'test') {
+        script.setAttribute('data-test-honeybadger', true);
+      }
 
       document.getElementsByTagName('head')[0].appendChild(script);
     });

--- a/addon/services/honeybadger.js
+++ b/addon/services/honeybadger.js
@@ -6,6 +6,7 @@ import { run } from '@ember/runloop';
 import { isPresent } from '@ember/utils';
 import { getOwner } from '@ember/application';
 import { set } from '@ember/object';
+import { deprecate } from '@ember/application/deprecations';
 
 const noop = () => {};
 
@@ -16,7 +17,7 @@ export default Service.extend({
   },
 
   notify(error) {
-    return this._getSDK().then(
+    return this.setup().then(
       () => {
         run(window.Honeybadger, 'notify', error);
       },
@@ -27,7 +28,11 @@ export default Service.extend({
     )
   },
 
-  _getSDK() {
+  resetMaxErrors() {
+    run(window.Honeybadger, 'resetMaxErrors');
+  },
+
+  setup() {
     if (typeof(window.Honeybadger) === 'object') {
       return resolve();
     }
@@ -39,7 +44,20 @@ export default Service.extend({
       }).catch((e) => {
         run(null, reject, e);
       });
-    }, 'service:honeybadger:getSDK');
+    }, 'service:honeybadger:setup');
+  },
+
+  _getSDK() {
+    deprecate(
+      '#_getSDK was made public and renamed to #setup',
+      false,
+      {
+        id: 'ember-cli-honey-badger._getSDK',
+        until: '3.0.0'
+      }
+    );
+
+    return this.setup();
   },
 
   _config() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-honeybadger-io",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Javascript error tracking with https://www.honeybadger.io",
   "keywords": [
     "ember-addon",

--- a/tests/unit/services/honeybadger-test.js
+++ b/tests/unit/services/honeybadger-test.js
@@ -106,4 +106,25 @@ module('Unit | Service | honeybadger', function(hooks) {
 
     assert.ok(window.Honeybadger.calledWith('resetMaxErrors'))
   })
+
+  test('Override config.version', async function(assert) {
+    let service = this.owner.lookup('service:honeybadger');
+
+    sinon.stub(service, '_resolveConfig' ).callsFake(() => {
+      return {
+        honeybadger: {
+          environment: 'test',
+          apiKey: 'test-key',
+          version: '3.0'
+        }
+      };
+    });
+
+    await service._getScript();
+
+    assert.equal(
+      document.querySelector('[data-test-honeybadger]').src,
+      'http://js.honeybadger.io/v3.0/honeybadger.min.js'
+    );
+  })
 });

--- a/tests/unit/services/honeybadger-test.js
+++ b/tests/unit/services/honeybadger-test.js
@@ -96,4 +96,14 @@ module('Unit | Service | honeybadger', function(hooks) {
       );
     });
   });
+
+  test('#resetMaxErrors', function(assert) {
+    let service = this.owner.lookup('service:honeybadger');
+
+    window.Honeybadger = sinon.stub();
+
+    service.resetMaxErrors();
+
+    assert.ok(window.Honeybadger.calledWith('resetMaxErrors'))
+  })
 });


### PR DESCRIPTION
Renamed `_getSDK` to `setup` and made it public. This allows add-on consumers to manually load in SDK when needed, e.g. when user is idle.

 - Exposed `resetMaxErrors` that is needed by single-page apps to help reduce noise.
 - Allow `version` to be configured, will allows us to upgrade honeybadger.js version before we get time to bump ember version in this repo.
 